### PR TITLE
Add Memorial entity with seed data and project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Lumos is an empathetic AI assistant for memorial pages that helps friends and family write obituaries and condolence messages. The application guides users through questions to generate meaningful, personalized content that serves as a starting point for expressing grief and comfort.
+
+## Architecture
+
+**Full-stack application:**
+- **Frontend**: React 18 (served via Nginx in production)
+- **Backend**: Spring Boot 3.2 with Java 17
+- **Database**: PostgreSQL 16
+- **Deployment**: Docker Compose (separate dev and prod configurations)
+
+**Communication:**
+- Frontend makes API calls to backend through `/api/*` endpoints
+- In Docker, frontend nginx proxies API requests to backend
+- Frontend uses `REACT_APP_API_URL` environment variable for API endpoint configuration
+
+**Package structure (backend):**
+- `com.example.backend` - Main application package
+- `com.example.backend.controller` - REST controllers
+
+## Development Commands
+
+### Local Development (with Docker)
+```bash
+# Start all services (frontend, backend, postgres)
+docker-compose up --build
+
+# Stop all services
+docker-compose down
+
+# Stop and remove volumes
+docker-compose down -v
+```
+
+**Service endpoints:**
+- Frontend: http://localhost:3000
+- Backend API: http://localhost:8080/api
+- PostgreSQL: localhost:5432 (db: appdb, user: postgres, pass: postgres)
+
+### Backend Development (requires Java 17 & Maven)
+```bash
+cd backend
+
+# Run application
+mvn spring-boot:run
+
+# Run tests
+mvn test
+
+# Build
+mvn clean package
+```
+
+### Frontend Development (requires Node.js 18+)
+```bash
+cd frontend
+
+# Install dependencies
+npm install
+
+# Start dev server
+npm start
+
+# Run tests
+npm test
+
+# Build for production
+npm run build
+```
+
+## Production Deployment
+
+**AWS EC2 deployment:**
+```bash
+# Deploy to production (uses docker-compose.prod.yml)
+./deploy.sh
+
+# Manual deployment steps
+docker-compose -f docker-compose.prod.yml down
+docker-compose -f docker-compose.prod.yml up -d --build
+```
+
+**Environment configuration:**
+- Copy `.env.example` to `.env` and configure for production
+- Update database password in production environment
+- The deploy script pulls from `master` branch
+
+## Database
+
+**Configuration:**
+- Hibernate auto-update enabled (`spring.jpa.hibernate.ddl-auto=update`)
+- SQL logging enabled in development
+- PostgreSQL dialect with JPA/Hibernate
+- Data persists in Docker volume `postgres_data`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Full Stack Application
+# Lumos - Memorial Page Writing Assistant
 
-A basic full-stack application with React frontend, Spring Boot backend, and PostgreSQL database.
+An empathetic AI assistant to help friends and family find the right words when creating obituaries and condolence messages for memorial pages.
+
+## About
+
+Lumos helps people express their grief and give comfort to others during difficult times. The application guides users through a series of thoughtful questions to generate meaningful, personalized content for memorial pages - whether writing an obituary or a condolence message. The AI-generated text serves as a compassionate starting point that users can then edit, extend, and refine to truly capture their feelings and memories.
 
 ## Tech Stack
 

--- a/backend/src/main/java/com/example/backend/config/DataSeeder.java
+++ b/backend/src/main/java/com/example/backend/config/DataSeeder.java
@@ -1,0 +1,203 @@
+package com.example.backend.config;
+
+import com.example.backend.entity.Memorial;
+import com.example.backend.repository.MemorialRepository;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+@Configuration
+public class DataSeeder {
+
+    @Bean
+    CommandLineRunner initDatabase(MemorialRepository repository) {
+        return args -> {
+            if (repository.count() == 0) {
+                List<Memorial> memorials = Arrays.asList(
+                    createSwedish1(),
+                    createSwedish2(),
+                    createSwedish3(),
+                    createSwedish4(),
+                    createGerman1(),
+                    createGerman2(),
+                    createGerman3(),
+                    createGerman4(),
+                    createEnglish1(),
+                    createEnglish2(),
+                    createEnglish3(),
+                    createEnglish4()
+                );
+
+                repository.saveAll(memorials);
+                System.out.println("✅ Seeded " + memorials.size() + " memorial cases");
+            }
+        };
+    }
+
+    private Memorial createSwedish1() {
+        Memorial m = new Memorial();
+        m.setFirstName("Astrid");
+        m.setLastName("Bergström");
+        m.setBornDate(LocalDate.of(1945, 3, 12));
+        m.setDeathDate(LocalDate.of(2024, 9, 28));
+        m.setPlaceOfBirth("Stockholm, Sverige");
+        m.setPlaceOfDeath("Uppsala, Sverige");
+        m.setBiography("Astrid var en älskad lärare som ägnade sitt liv åt att utbilda barn i matematik och naturvetenskap. Hon var känd för sitt tålamod och sin förmåga att få även de mest osäkra eleverna att tro på sig själva. På fritiden älskade hon att vandra i svenska fjällen och måla akvareller.");
+        m.setObituary("Med saknad tar vi farväl av vår älskade Astrid Bergström som stilla somnade in omgiven av sina närmaste. Hon lämnar efter sig ett stort tomrum men också många ljusa minnen hos alla som kände henne.");
+        return m;
+    }
+
+    private Memorial createSwedish2() {
+        Memorial m = new Memorial();
+        m.setFirstName("Erik");
+        m.setMiddleName("Johan");
+        m.setLastName("Andersson");
+        m.setBornDate(LocalDate.of(1962, 7, 22));
+        m.setDeathDate(LocalDate.of(2024, 10, 5));
+        m.setPlaceOfBirth("Göteborg, Sverige");
+        m.setPlaceOfDeath("Göteborg, Sverige");
+        m.setBiography("Erik var en hängiven fiskare och naturälskare som tillbringade varje ledig stund vid havet. Han arbetade som skeppsmekaniker i 35 år och var känd för sitt skratt och sina ändlösa sjömannahistorier. Hans passion för livet och hans generositet kommer att saknas djupt av familj och vänner.");
+        m.setObituary("Vår älskade make, pappa och morfar Erik har lämnat oss efter en tids sjukdom. Han var vår klippa, vår glädje och vårt allt. Vi är tacksamma för alla år vi fick tillsammans.");
+        return m;
+    }
+
+    private Memorial createSwedish3() {
+        Memorial m = new Memorial();
+        m.setFirstName("Linnea");
+        m.setLastName("Svensson");
+        m.setBornDate(LocalDate.of(2001, 11, 8));
+        m.setDeathDate(LocalDate.of(2024, 8, 15));
+        m.setPlaceOfBirth("Malmö, Sverige");
+        m.setPlaceOfDeath("Lund, Sverige");
+        m.setBiography("Linnea var en lysande ung själ med ett stort hjärta för djur och natur. Hon studerade veterinärmedicin och drömde om att arbeta med vilda djur. Hennes vänner beskrev henne som en solstråle som alltid fick andra att känna sig sedda och hörda. Hon älskade att spela gitarr och skriva egna låtar.");
+        m.setObituary("Vår älskade dotter Linnea rycks alltför tidigt bort från oss. Hon hade så mycket kvar att ge och uppleva. Hennes ljus kommer att lysa vidare i alla våra hjärtan.");
+        return m;
+    }
+
+    private Memorial createSwedish4() {
+        Memorial m = new Memorial();
+        m.setFirstName("Gunnar");
+        m.setMiddleName("Bertil");
+        m.setLastName("Lindqvist");
+        m.setBornDate(LocalDate.of(1938, 1, 30));
+        m.setDeathDate(LocalDate.of(2024, 9, 12));
+        m.setPlaceOfBirth("Kiruna, Sverige");
+        m.setPlaceOfDeath("Stockholm, Sverige");
+        m.setBiography("Gunnar levde ett långt och händelserikt liv. Han arbetade i gruvan i Kiruna innan han flyttade söderut och startade eget företag. En storhjärtad man som alltid ställde upp för sina vänner och familj. Han var gift i 58 år med sin älskade Ingrid och tillsammans hade de tre barn, sju barnbarn och fyra barnbarnsbarn.");
+        m.setObituary("I djup sorg meddelar vi att vår make, pappa, morfar och farfar Gunnar har gått bort efter ett långt och välfyllt liv. Han var vår stolthet och vår inspiration. Vila i frid, du kommer alltid att finnas i våra hjärtan.");
+        return m;
+    }
+
+    private Memorial createGerman1() {
+        Memorial m = new Memorial();
+        m.setFirstName("Klaus");
+        m.setMiddleName("Dieter");
+        m.setLastName("Müller");
+        m.setBornDate(LocalDate.of(1955, 6, 18));
+        m.setDeathDate(LocalDate.of(2024, 10, 1));
+        m.setPlaceOfBirth("München, Deutschland");
+        m.setPlaceOfDeath("München, Deutschland");
+        m.setBiography("Klaus war ein leidenschaftlicher Ingenieur bei BMW, der über 40 Jahre lang an der Entwicklung innovativer Automobiltechnologien arbeitete. Er war bekannt für seine Präzision, seinen Humor und seine Liebe zum FC Bayern München. In seiner Freizeit restaurierte er gerne alte Motorräder und verbrachte Zeit mit seinen Enkelkindern.");
+        m.setObituary("In stiller Trauer nehmen wir Abschied von unserem geliebten Klaus. Er war ein wunderbarer Ehemann, Vater und Großvater. Seine Güte und sein Lachen werden uns für immer fehlen.");
+        return m;
+    }
+
+    private Memorial createGerman2() {
+        Memorial m = new Memorial();
+        m.setFirstName("Helga");
+        m.setLastName("Schmidt");
+        m.setBornDate(LocalDate.of(1942, 9, 5));
+        m.setDeathDate(LocalDate.of(2024, 9, 20));
+        m.setPlaceOfBirth("Hamburg, Deutschland");
+        m.setPlaceOfDeath("Hamburg, Deutschland");
+        m.setBiography("Helga widmete ihr Leben der Musik. Als Klavierlehrerin inspirierte sie Generationen von Schülern und half vielen, ihre Liebe zur klassischen Musik zu entdecken. Sie war eine warmherzige Frau, die für ihre Apfelstrudel und ihre offene Tür bekannt war. Ihre größte Freude war es, mit ihrer Familie zusammen zu sein.");
+        m.setObituary("Unsere geliebte Mutter und Oma Helga ist friedlich eingeschlafen. Sie hinterlässt eine große Lücke in unseren Herzen, aber auch unzählige schöne Erinnerungen. Ruhe in Frieden.");
+        return m;
+    }
+
+    private Memorial createGerman3() {
+        Memorial m = new Memorial();
+        m.setFirstName("Anna");
+        m.setMiddleName("Marie");
+        m.setLastName("Fischer");
+        m.setBornDate(LocalDate.of(1995, 4, 14));
+        m.setDeathDate(LocalDate.of(2024, 7, 30));
+        m.setPlaceOfBirth("Berlin, Deutschland");
+        m.setPlaceOfDeath("Berlin, Deutschland");
+        m.setBiography("Anna war eine talentierte Grafikdesignerin mit einer außergewöhnlichen Kreativität. Sie liebte es, durch ihre Kunst Geschichten zu erzählen und arbeitete für verschiedene gemeinnützige Organisationen. Ihre Freunde beschreiben sie als eine Person voller Energie, Mitgefühl und unbändiger Lebensfreude. Sie reiste gerne und träumte davon, die Welt zu verändern.");
+        m.setObituary("Viel zu früh wurde uns unsere geliebte Tochter Anna entrissen. Ihr Licht, ihre Liebe und ihr Lachen werden für immer in unseren Herzen weiterleben. Wir sind dankbar für jeden Moment, den wir mit ihr teilen durften.");
+        return m;
+    }
+
+    private Memorial createGerman4() {
+        Memorial m = new Memorial();
+        m.setFirstName("Werner");
+        m.setLastName("Hoffmann");
+        m.setBornDate(LocalDate.of(1950, 12, 3));
+        m.setDeathDate(LocalDate.of(2024, 10, 3));
+        m.setPlaceOfBirth("Frankfurt, Deutschland");
+        m.setPlaceOfDeath("Köln, Deutschland");
+        m.setBiography("Werner war Architekt aus Leidenschaft. Seine Gebäude prägen bis heute das Stadtbild von Köln. Er war ein Mann mit Vision, der Moderne und Tradition meisterhaft verband. Außerhalb seiner Arbeit war er ein begeisterter Weinsammler und Hobby-Koch, der es liebte, Freunde zu bewirten.");
+        m.setObituary("Mit tiefer Trauer verabschieden wir uns von Werner, einem außergewöhnlichen Menschen, der uns mit seiner Weisheit, seinem Talent und seiner Großzügigkeit bereichert hat. Er wird unvergessen bleiben.");
+        return m;
+    }
+
+    private Memorial createEnglish1() {
+        Memorial m = new Memorial();
+        m.setFirstName("Margaret");
+        m.setMiddleName("Rose");
+        m.setLastName("Thompson");
+        m.setBornDate(LocalDate.of(1948, 5, 22));
+        m.setDeathDate(LocalDate.of(2024, 9, 15));
+        m.setPlaceOfBirth("London, United Kingdom");
+        m.setPlaceOfDeath("Brighton, United Kingdom");
+        m.setBiography("Margaret was a devoted nurse who spent 45 years caring for others in the NHS. She had a gentle spirit and was known for her compassion and unwavering dedication to her patients. Outside of work, she loved gardening, baking Victoria sponge cakes, and spending time with her five grandchildren at the seaside.");
+        m.setObituary("We sadly announce the passing of our beloved Margaret, a wonderful mother, grandmother, and friend. She touched countless lives with her kindness and will be deeply missed by all who knew her. Rest in peace, dear Mum.");
+        return m;
+    }
+
+    private Memorial createEnglish2() {
+        Memorial m = new Memorial();
+        m.setFirstName("James");
+        m.setMiddleName("Patrick");
+        m.setLastName("O'Connor");
+        m.setBornDate(LocalDate.of(1967, 8, 10));
+        m.setDeathDate(LocalDate.of(2024, 10, 2));
+        m.setPlaceOfBirth("Dublin, Ireland");
+        m.setPlaceOfDeath("Manchester, United Kingdom");
+        m.setBiography("James was a passionate teacher and rugby coach who inspired young people throughout his career. He moved from Dublin to Manchester in his twenties and made it his home. Known for his infectious laugh and love of Irish music, he could always be found at the local pub on a Friday night, entertaining friends with his stories and guitar playing.");
+        m.setObituary("It is with heavy hearts that we say goodbye to James, our beloved husband, father, and friend. His zest for life, his humor, and his generous heart will be remembered by all. May he rest in eternal peace.");
+        return m;
+    }
+
+    private Memorial createEnglish3() {
+        Memorial m = new Memorial();
+        m.setFirstName("Emily");
+        m.setLastName("Williams");
+        m.setBornDate(LocalDate.of(1998, 2, 28));
+        m.setDeathDate(LocalDate.of(2024, 8, 20));
+        m.setPlaceOfBirth("Bristol, United Kingdom");
+        m.setPlaceOfDeath("Bristol, United Kingdom");
+        m.setBiography("Emily was a bright young soul with a passion for environmental activism and sustainable living. She was studying Environmental Science at university and dreamed of working to protect endangered species. Her friends describe her as fearless, compassionate, and always ready to stand up for what she believed in. She loved hiking, photography, and her rescue dog Luna.");
+        m.setObituary("Our precious daughter Emily was taken from us far too soon. She had so much love to give and so many dreams yet to fulfill. Her spirit will live on in the hearts of everyone she touched. Forever in our thoughts.");
+        return m;
+    }
+
+    private Memorial createEnglish4() {
+        Memorial m = new Memorial();
+        m.setFirstName("Robert");
+        m.setMiddleName("Henry");
+        m.setLastName("Davies");
+        m.setBornDate(LocalDate.of(1935, 11, 12));
+        m.setDeathDate(LocalDate.of(2024, 9, 25));
+        m.setPlaceOfBirth("Cardiff, Wales");
+        m.setPlaceOfDeath("Edinburgh, Scotland");
+        m.setBiography("Robert lived a remarkable life spanning nearly nine decades. A proud Welshman, he served in the Royal Navy before becoming a history professor at the University of Edinburgh. He was a devoted husband to his late wife Elizabeth for 62 years, and together they raised four children. Robert loved poetry, whisky, and long walks in the Scottish Highlands.");
+        m.setObituary("With profound sadness, we announce the passing of our father, grandfather, and great-grandfather Robert. He was a man of wisdom, dignity, and unwavering principle. His legacy lives on through his family and the many students he mentored. Rest peacefully, Dad.");
+        return m;
+    }
+}

--- a/backend/src/main/java/com/example/backend/entity/Memorial.java
+++ b/backend/src/main/java/com/example/backend/entity/Memorial.java
@@ -1,0 +1,162 @@
+package com.example.backend.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "memorials")
+public class Memorial {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String firstName;
+
+    @Column(nullable = false)
+    private String lastName;
+
+    private String middleName;
+
+    @Column(nullable = false)
+    private LocalDate bornDate;
+
+    @Column(nullable = false)
+    private LocalDate deathDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String biography;
+
+    @Column(columnDefinition = "TEXT")
+    private String obituary;
+
+    private String profileImageUrl;
+
+    private String placeOfBirth;
+
+    private String placeOfDeath;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public LocalDate getBornDate() {
+        return bornDate;
+    }
+
+    public void setBornDate(LocalDate bornDate) {
+        this.bornDate = bornDate;
+    }
+
+    public LocalDate getDeathDate() {
+        return deathDate;
+    }
+
+    public void setDeathDate(LocalDate deathDate) {
+        this.deathDate = deathDate;
+    }
+
+    public String getBiography() {
+        return biography;
+    }
+
+    public void setBiography(String biography) {
+        this.biography = biography;
+    }
+
+    public String getObituary() {
+        return obituary;
+    }
+
+    public void setObituary(String obituary) {
+        this.obituary = obituary;
+    }
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+
+    public void setProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public String getPlaceOfBirth() {
+        return placeOfBirth;
+    }
+
+    public void setPlaceOfBirth(String placeOfBirth) {
+        this.placeOfBirth = placeOfBirth;
+    }
+
+    public String getPlaceOfDeath() {
+        return placeOfDeath;
+    }
+
+    public void setPlaceOfDeath(String placeOfDeath) {
+        this.placeOfDeath = placeOfDeath;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/src/main/java/com/example/backend/repository/MemorialRepository.java
+++ b/backend/src/main/java/com/example/backend/repository/MemorialRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend.repository;
+
+import com.example.backend.entity.Memorial;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemorialRepository extends JpaRepository<Memorial, Long> {
+}


### PR DESCRIPTION
## Summary
- Created Memorial entity with fields for memorial page data (names, dates, biography, obituary, places, etc.)
- Added MemorialRepository JPA interface
- Implemented DataSeeder with 12 diverse memorial cases (4 Swedish, 4 German, 4 English)
- Updated README with Lumos project description and purpose
- Added CLAUDE.md with development commands and architecture overview

## Database
The Memorial entity will be auto-created by Hibernate on application startup. The seeder populates 12 varied example cases spanning different ages, backgrounds, and life stories to provide realistic test data.

## Test plan
- [ ] Start application with `docker-compose up --build`
- [ ] Verify database table is created automatically
- [ ] Verify 12 memorial records are seeded on first startup
- [ ] Check logs for "✅ Seeded 12 memorial cases" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)